### PR TITLE
Property Details Page: Socioeconomic data accordion items

### DIFF
--- a/blocks/property-details-economic-data/property-details-economic-data.js
+++ b/blocks/property-details-economic-data/property-details-economic-data.js
@@ -1,0 +1,63 @@
+import { createAccordionItem } from '../../scripts/accordion.js';
+import { decorateIcons, loadCSS } from '../../scripts/lib-franklin.js';
+
+const socioEconomicAPI = 'https://www.bhhs.com/bin/bhhs/pdp/socioEconomicDataServlet?latitude=42.56574249267578&longitude=-70.76632690429688';
+
+function createTableRow(levelData) {
+  const label = levelData.level == 'zipcode' ? `Zip Code: ${levelData.label}` : levelData.label;
+  var rowHTML = `
+    <tr>
+      <td>
+        <h6>${label}</h6>
+      </td>
+      <td class="cmp-socio-economic-data__stat usd">
+        <div class="currency">${levelData.medianIncome}</div>
+      </td>
+      <td class="cmp-socio-economic-data__stat percentage">
+        ${levelData.unemploymentPercent}
+        <span class="percentage">%</span></td>
+      <td class="cmp-socio-economic-data__stat">
+        ${levelData.costOfLivingIndex}
+      </td>
+    </tr>
+  `;
+  return rowHTML;
+}
+
+export default async function decorate(block) {
+  const resp = await fetch(socioEconomicAPI);
+  if (resp.ok) {
+    const econData = await resp.json();
+    const data = econData.data;
+    const citation = 'Data provided by U.S. Census Bureau';
+    var econTableHTML = `
+      <div class="property-container">
+        <div class="property-row">
+          <div class="col col-12 col-lg-10 offset-lg-1 col-md-10 offset-md-1">
+            <table class="cmp-socio-economic-data--table">
+              <thead slot="head">
+                <th aria-label="No value"></th>
+                <th>Median House. Income</th>
+                <th>Unemployment</th>
+                <th>Cost of Living Index</th>
+              </thead>
+              <tbody>
+    `;
+    data.forEach((elem) => {
+      econTableHTML += createTableRow(elem);
+    });
+    econTableHTML += `
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    `;
+    var econAccordionItem = createAccordionItem('economic-data', 'Economic Data', econTableHTML, citation);
+    block.append(econAccordionItem);
+    decorateIcons(block);
+    loadCSS(`${window.hlx.codeBasePath}/styles/templates/accordion/accordion.css`);
+    loadCSS(`${window.hlx.codeBasePath}/styles/templates/property-details/property-details.css`);
+    loadCSS(`${window.hlx.codeBasePath}/styles/templates/property-details/property-details-table.css`);
+  }
+}

--- a/blocks/property-details-economic-data/property-details-economic-data.js
+++ b/blocks/property-details-economic-data/property-details-economic-data.js
@@ -4,8 +4,8 @@ import { decorateIcons, loadCSS } from '../../scripts/lib-franklin.js';
 const socioEconomicAPI = 'https://www.bhhs.com/bin/bhhs/pdp/socioEconomicDataServlet?latitude=42.56574249267578&longitude=-70.76632690429688';
 
 function createTableRow(levelData) {
-  const label = levelData.level == 'zipcode' ? `Zip Code: ${levelData.label}` : levelData.label;
-  var rowHTML = `
+  const label = levelData.level === 'zipcode' ? `Zip Code: ${levelData.label}` : levelData.label;
+  const rowHTML = `
     <tr>
       <td>
         <h6>${label}</h6>
@@ -27,10 +27,10 @@ function createTableRow(levelData) {
 export default async function decorate(block) {
   const resp = await fetch(socioEconomicAPI);
   if (resp.ok) {
-    const econData = await resp.json();
-    const data = econData.data;
+    const socioEconJSON = await resp.json();
+    const { data: socioEconData } = socioEconJSON;
     const citation = 'Data provided by U.S. Census Bureau';
-    var econTableHTML = `
+    let econTableHTML = `
       <div class="property-container">
         <div class="property-row">
           <div class="col col-12 col-lg-10 offset-lg-1 col-md-10 offset-md-1">
@@ -43,7 +43,7 @@ export default async function decorate(block) {
               </thead>
               <tbody>
     `;
-    data.forEach((elem) => {
+    socioEconData.forEach((elem) => {
       econTableHTML += createTableRow(elem);
     });
     econTableHTML += `
@@ -53,7 +53,7 @@ export default async function decorate(block) {
         </div>
       </div>
     `;
-    var econAccordionItem = createAccordionItem('economic-data', 'Economic Data', econTableHTML, citation);
+    const econAccordionItem = createAccordionItem('economic-data', 'Economic Data', econTableHTML, citation);
     block.append(econAccordionItem);
     decorateIcons(block);
     loadCSS(`${window.hlx.codeBasePath}/styles/templates/accordion/accordion.css`);

--- a/blocks/property-details-housing-trends/property-details-housing-trends.js
+++ b/blocks/property-details-housing-trends/property-details-housing-trends.js
@@ -4,8 +4,8 @@ import { decorateIcons, loadCSS } from '../../scripts/lib-franklin.js';
 const socioEconomicAPI = 'https://www.bhhs.com/bin/bhhs/pdp/socioEconomicDataServlet?latitude=42.56574249267578&longitude=-70.76632690429688';
 
 function createTableRow(levelData) {
-  const label = levelData.level == 'zipcode' ? `Zip Code: ${levelData.label}` : levelData.label;
-  var rowHTML = `
+  const label = levelData.level === 'zipcode' ? `Zip Code: ${levelData.label}` : levelData.label;
+  const rowHTML = `
     <tr>
       <td>
         <h6>${label}</h6>
@@ -23,10 +23,10 @@ function createTableRow(levelData) {
 export default async function decorate(block) {
   const resp = await fetch(socioEconomicAPI);
   if (resp.ok) {
-    const econData = await resp.json();
-    const data = econData.data;
+    const socioEconJSON = await resp.json();
+    const { data: socioEconData } = socioEconJSON;
     const citation = 'Market data provided by U.S. Census Bureau';
-    var housingTableHTML = `
+    let housingTableHTML = `
       <div class="property-container">
         <div class="property-row">
           <div class="col col-12 col-lg-10 offset-lg-1 col-md-10 offset-md-1">
@@ -39,7 +39,7 @@ export default async function decorate(block) {
               </thead>
               <tbody>
     `;
-    data.forEach((elem) => {
+    socioEconData.forEach((elem) => {
       housingTableHTML += createTableRow(elem);
     });
     housingTableHTML += `
@@ -49,7 +49,7 @@ export default async function decorate(block) {
         </div>
       </div>
     `;
-    var housingAccordionItem = createAccordionItem('housing-trends', 'Housing Trends', housingTableHTML, citation);
+    const housingAccordionItem = createAccordionItem('housing-trends', 'Housing Trends', housingTableHTML, citation);
     block.append(housingAccordionItem);
     decorateIcons(block);
     loadCSS(`${window.hlx.codeBasePath}/styles/templates/accordion/accordion.css`);

--- a/blocks/property-details-housing-trends/property-details-housing-trends.js
+++ b/blocks/property-details-housing-trends/property-details-housing-trends.js
@@ -1,0 +1,59 @@
+import { createAccordionItem } from '../../scripts/accordion.js';
+import { decorateIcons, loadCSS } from '../../scripts/lib-franklin.js';
+
+const socioEconomicAPI = 'https://www.bhhs.com/bin/bhhs/pdp/socioEconomicDataServlet?latitude=42.56574249267578&longitude=-70.76632690429688';
+
+function createTableRow(levelData) {
+  const label = levelData.level == 'zipcode' ? `Zip Code: ${levelData.label}` : levelData.label;
+  var rowHTML = `
+    <tr>
+      <td>
+        <h6>${label}</h6>
+      </td>
+      <td class="cmp-socio-economic-data__stat percentage">
+        ${levelData.homeValueAppreciationPercent}
+        <span class="percentage">%</span></td>
+      <td class="cmp-socio-economic-data__stat year">${levelData.medianHomeAge}y</td>
+      <td></td>
+    </tr>
+  `;
+  return rowHTML;
+}
+
+export default async function decorate(block) {
+  const resp = await fetch(socioEconomicAPI);
+  if (resp.ok) {
+    const econData = await resp.json();
+    const data = econData.data;
+    const citation = 'Market data provided by U.S. Census Bureau';
+    var housingTableHTML = `
+      <div class="property-container">
+        <div class="property-row">
+          <div class="col col-12 col-lg-10 offset-lg-1 col-md-10 offset-md-1">
+            <table class="cmp-socio-economic-data--table">
+              <thead slot="head">
+                <th aria-label="No value"></th>
+                <th>Home Appreciation</th>
+                <th>Median Age</th>
+                <th aria-label="No value"></th>
+              </thead>
+              <tbody>
+    `;
+    data.forEach((elem) => {
+      housingTableHTML += createTableRow(elem);
+    });
+    housingTableHTML += `
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    `;
+    var housingAccordionItem = createAccordionItem('housing-trends', 'Housing Trends', housingTableHTML, citation);
+    block.append(housingAccordionItem);
+    decorateIcons(block);
+    loadCSS(`${window.hlx.codeBasePath}/styles/templates/accordion/accordion.css`);
+    loadCSS(`${window.hlx.codeBasePath}/styles/templates/property-details/property-details.css`);
+    loadCSS(`${window.hlx.codeBasePath}/styles/templates/property-details/property-details-table.css`);
+  }
+}

--- a/blocks/property-details-occupancy/property-details-occupancy.js
+++ b/blocks/property-details-occupancy/property-details-occupancy.js
@@ -1,0 +1,65 @@
+import { createAccordionItem } from '../../scripts/accordion.js';
+import { decorateIcons, loadCSS } from '../../scripts/lib-franklin.js';
+
+const socioEconomicAPI = 'https://www.commonmoves.com/bin/bhhs/pdp/socioEconomicDataServlet?latitude=42.56574249267578&longitude=-70.76632690429688';
+
+function createTableRow(levelData) {
+  const label = levelData.level == 'zipcode' ? `Zip Code: ${levelData.label}` : levelData.label;
+  var rowHTML = `
+    <tr>
+      <td>
+        <h6>${label}</h6>
+      </td>
+      <td class="cmp-socio-economic-data__stat">
+        ${levelData.ownerOccupiedPercent}
+        <span class="percentage">%</span>
+        <div class="progress-bar"><span class="progress-owner" style="width: ${levelData.ownerOccupiedPercent}%;"></span> <span class="progress-renter"
+            style="width: ${levelData.renterOccupiedPercent}%;"></span></div>
+      </td>
+      <td class="cmp-socio-economic-data__stat percentage">
+        ${levelData.renterOccupiedPercent}
+        <span class="percentage">%</span></td>
+      <td class="cmp-socio-economic-data__stat percentage">
+        ${levelData.vacancyPercent}
+        <span class="percentage">%</span></td>
+    </tr>
+  `;
+  return rowHTML;
+}
+export default async function decorate(block) {
+  const resp = await fetch(socioEconomicAPI);
+  if (resp.ok) {
+    const econData = await resp.json();
+    const data = econData.data;
+    const citation = 'Market data provided by U.S. Census Bureau';
+    var occupancyHTML = `
+      <div class="property-container">
+        <div class="property-row">
+          <div class="col col-12 col-lg-10 offset-lg-1 col-md-10 offset-md-1">
+            <table class="cmp-socio-economic-data--table">
+              <thead slot="head">
+                <th aria-label="No value"></th>
+                <th>Owned</th>
+                <th>Rented</th>
+                <th aria-label="No value">Vacant</th>
+              </thead>
+              <tbody>
+    `;
+    data.forEach((elem) => {
+      occupancyHTML += createTableRow(elem);
+    });
+    occupancyHTML += `
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    `;
+    var occupancyAccordionItem = createAccordionItem('occupancy', 'Occupancy', occupancyHTML, citation);
+    block.append(occupancyAccordionItem);
+    decorateIcons(block);
+    loadCSS(`${window.hlx.codeBasePath}/styles/templates/accordion/accordion.css`);
+    loadCSS(`${window.hlx.codeBasePath}/styles/templates/property-details/property-details.css`);
+    loadCSS(`${window.hlx.codeBasePath}/styles/templates/property-details/property-details-table.css`);
+  }
+}

--- a/blocks/property-details-occupancy/property-details-occupancy.js
+++ b/blocks/property-details-occupancy/property-details-occupancy.js
@@ -4,8 +4,8 @@ import { decorateIcons, loadCSS } from '../../scripts/lib-franklin.js';
 const socioEconomicAPI = 'https://www.commonmoves.com/bin/bhhs/pdp/socioEconomicDataServlet?latitude=42.56574249267578&longitude=-70.76632690429688';
 
 function createTableRow(levelData) {
-  const label = levelData.level == 'zipcode' ? `Zip Code: ${levelData.label}` : levelData.label;
-  var rowHTML = `
+  const label = levelData.level === 'zipcode' ? `Zip Code: ${levelData.label}` : levelData.label;
+  const rowHTML = `
     <tr>
       <td>
         <h6>${label}</h6>
@@ -29,10 +29,10 @@ function createTableRow(levelData) {
 export default async function decorate(block) {
   const resp = await fetch(socioEconomicAPI);
   if (resp.ok) {
-    const econData = await resp.json();
-    const data = econData.data;
+    const socioEconJSON = await resp.json();
+    const { data: socioEconData } = socioEconJSON;
     const citation = 'Market data provided by U.S. Census Bureau';
-    var occupancyHTML = `
+    let occupancyHTML = `
       <div class="property-container">
         <div class="property-row">
           <div class="col col-12 col-lg-10 offset-lg-1 col-md-10 offset-md-1">
@@ -45,7 +45,7 @@ export default async function decorate(block) {
               </thead>
               <tbody>
     `;
-    data.forEach((elem) => {
+    socioEconData.forEach((elem) => {
       occupancyHTML += createTableRow(elem);
     });
     occupancyHTML += `
@@ -55,7 +55,7 @@ export default async function decorate(block) {
         </div>
       </div>
     `;
-    var occupancyAccordionItem = createAccordionItem('occupancy', 'Occupancy', occupancyHTML, citation);
+    const occupancyAccordionItem = createAccordionItem('occupancy', 'Occupancy', occupancyHTML, citation);
     block.append(occupancyAccordionItem);
     decorateIcons(block);
     loadCSS(`${window.hlx.codeBasePath}/styles/templates/accordion/accordion.css`);

--- a/scripts/accordion.js
+++ b/scripts/accordion.js
@@ -1,19 +1,19 @@
 function openAccordion() {
-  var parent = this.closest('.accordion-item');
+  const parent = this.closest('.accordion-item');
   parent.classList.toggle('collapse');
 }
 
 function createAccordionHeader(heading, tooltipText) {
   const accordionTitle = document.createElement('div');
   accordionTitle.className = 'accordion-title';
-  var headerHTML = `
+  let headerHTML = `
     <div class="property-container">
       <div class="property-row">
         <div class="col col-12 offset-md-1 col-md-10">
           <div class="accordion-header">
             <h2 class="accordion-header-title">${heading}</h2>
   `;
-  if(tooltipText) {
+  if (tooltipText) {
     headerHTML += `
             <div class="tooltip">
               <span class="icon icon-info_circle"></span>
@@ -32,7 +32,7 @@ function createAccordionHeader(heading, tooltipText) {
   return accordionTitle;
 }
 
-export function createAccordionItem(className, headerTitle, innerHTML, citation='') {
+function createAccordionItem(className, headerTitle, innerHTML, citation = '') {
   const accordionItem = document.createElement('div');
   accordionItem.className = `accordion-item ${className}`;
   const accordionTitle = createAccordionHeader(headerTitle, citation);
@@ -41,7 +41,12 @@ export function createAccordionItem(className, headerTitle, innerHTML, citation=
   accordionBody.innerHTML = innerHTML;
   accordionItem.append(accordionTitle);
   accordionItem.append(accordionBody);
-  var accordionHeader = accordionItem.querySelector('.accordion-header');
+  const accordionHeader = accordionItem.querySelector('.accordion-header');
   accordionHeader.addEventListener('click', openAccordion);
   return accordionItem;
 }
+
+export {
+  createAccordionItem,
+  createAccordionHeader,
+};

--- a/scripts/accordion.js
+++ b/scripts/accordion.js
@@ -1,0 +1,47 @@
+function openAccordion() {
+  var parent = this.closest('.accordion-item');
+  parent.classList.toggle('collapse');
+}
+
+function createAccordionHeader(heading, tooltipText) {
+  const accordionTitle = document.createElement('div');
+  accordionTitle.className = 'accordion-title';
+  var headerHTML = `
+    <div class="property-container">
+      <div class="property-row">
+        <div class="col col-12 offset-md-1 col-md-10">
+          <div class="accordion-header">
+            <h2 class="accordion-header-title">${heading}</h2>
+  `;
+  if(tooltipText) {
+    headerHTML += `
+            <div class="tooltip">
+              <span class="icon icon-info_circle"></span>
+              <span class="icon icon-info_circle_dark"></span>
+              <span class="tooltiptext">${tooltipText}</span>
+            </div>
+    `;
+  }
+  headerHTML += `
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+  accordionTitle.innerHTML = headerHTML;
+  return accordionTitle;
+}
+
+export function createAccordionItem(className, headerTitle, innerHTML, citation='') {
+  const accordionItem = document.createElement('div');
+  accordionItem.className = `accordion-item ${className}`;
+  const accordionTitle = createAccordionHeader(headerTitle, citation);
+  const accordionBody = document.createElement('div');
+  accordionBody.className = 'accordion-body';
+  accordionBody.innerHTML = innerHTML;
+  accordionItem.append(accordionTitle);
+  accordionItem.append(accordionBody);
+  var accordionHeader = accordionItem.querySelector('.accordion-header');
+  accordionHeader.addEventListener('click', openAccordion);
+  return accordionItem;
+}

--- a/styles/templates/accordion/accordion.css
+++ b/styles/templates/accordion/accordion.css
@@ -1,0 +1,116 @@
+.accordion-item .accordion-body {
+  max-height: 999em;
+  overflow: hidden;
+  transition: max-height .6s;
+}
+
+.accordion-item.collapse .accordion-body {
+  max-height: 0;
+}
+
+.accordion-header {
+  border-top: 1px solid var(--grey);
+  cursor: pointer;
+  padding: 16px 30px 16px 0;
+  position: relative;
+  display: block;
+}
+
+.accordion-header-title {
+  display: inline-block;
+  font-family: var(--font-family-georgia);
+  font-weight: var(--font-weight-semibold);
+  line-height: 26px;
+  margin: 0 5px 0 0;
+  font-size: 22px;
+}
+
+.accordion-item .accordion-header::after {
+  border-color: var(--body-color) transparent transparent transparent;
+  border-style: solid;
+  border-width: 6px 5px 0 5px;
+  content: '';
+  display: block;
+  height: 0;
+  margin-top: -5px;
+  position: absolute;
+  right: 2px;
+  top: 50%;
+  transition: transform .3s linear;
+  transform: rotate(0);
+  width: 0;
+}
+
+.accordion-item.collapse .accordion-header::after {
+  transform: rotate(90deg);
+  transition: transform .3s linear;
+}
+
+.tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip svg {
+  height: 19px;
+  width: 19px;
+}
+
+.tooltip .icon-info_circle_dark {
+  display: none;
+}
+
+.tooltip .tooltiptext {
+  visibility: hidden;
+  width: 290px;
+  background-color: var(--black);
+  color: var(--white);
+  text-align: left;
+  padding: 14px 18px;
+  position: absolute;
+  z-index: 1;
+  top: 100%;
+  left: 0;
+  margin: 12px 0 0 -10px;
+  font-family: var(--font-family-proxima);
+  font-size: var(--body-font-size-s);
+  letter-spacing: .44px;
+  line-height: 22px;
+}
+
+.tooltip:hover .icon-info_circle {
+  display: none;
+}
+
+.tooltip:hover .icon-info_circle_dark {
+  display: block;
+}
+
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+}
+
+.tooltip .tooltiptext::before {
+  content: '';
+  position: absolute;
+  bottom: 100%;
+  left: 8px;
+  border-width: 10px;
+  border-style: solid;
+  border-color: transparent transparent var(--black) transparent;
+}
+
+@media (min-width: 992px) {
+  .accordion-header {
+    padding: 27px 30px 30px 0;
+  }
+
+  .accordion-header-title {
+    font-size: var(--body-font-size-xl);
+    letter-spacing: -0.43px;
+  }
+
+  .accordion-item .accordion-header::after {
+    border-width: 9px 7px 0 7px;
+  }
+}

--- a/styles/templates/property-details/property-details-table.css
+++ b/styles/templates/property-details/property-details-table.css
@@ -1,0 +1,87 @@
+.cmp-socio-economic-data--table {
+  width: 100%;
+  position: relative;
+}
+
+.cmp-socio-economic-data--table thead {
+  vertical-align: top;
+}
+
+.cmp-socio-economic-data--table thead th {
+  padding: 40px 0 20px;
+  font-family: var(--font-family-proxima);
+  font-weight: var(--normal-page-width);
+  font-size: var(--body-font-size-m);
+  line-height: 23px;
+  letter-spacing: initial;
+  color: var(--body-color);
+}
+
+.cmp-socio-economic-data--table tbody {
+  display: table-row-group;
+  vertical-align: middle;
+  border-color: inherit;
+}
+
+.cmp-socio-economic-data--table tbody tr:first-of-type {
+  background: var(--light-grey);
+}
+
+.cmp-socio-economic-data--table tbody tr {
+  border-top: 1px solid var(--light-grey);
+  padding: 0 20px;
+  position: relative;
+}
+
+.cmp-socio-economic-data--table td {
+  width: 25%;
+  padding: 40px 0;
+}
+
+.cmp-socio-economic-data--table h6 {
+  margin: 0;
+  padding-left: 20px;
+  font-size: var(--body-font-size-s);
+  line-height: 35px;
+  font-family: var(--font-family-proxima);
+  text-transform: uppercase;
+}
+
+.cmp-socio-economic-data__stat {
+  position: relative;
+  font-size: var(--body-font-size-xxxl);
+  font-family: var(--font-family-proxima);
+  font-weight: var(--font-weight-light);
+}
+
+.cmp-socio-economic-data__stat .percentage {
+  content: "%";
+  font-size: var( --body-font-size-l);
+  letter-spacing: 0;
+  vertical-align: super;
+  margin-left: 0;
+  margin-top: -7px;
+  position: absolute;
+}
+
+.cmp-socio-economic-data__stat .progress-bar {
+  width: calc(100% - 100px);
+  position: relative;
+  margin-left: 80px;
+}
+
+.cmp-socio-economic-data__stat .progress-owner {
+  height: 2px;
+  background: var(--primary-color);
+  position: absolute;
+  left: 0;
+  margin-top: -15px;
+}
+
+.cmp-socio-economic-data__stat .progress-renter {
+  height: 2px;
+  background: var(--light-grey);
+  position: absolute;
+  right: 0;
+  margin-top: -15px;
+}

--- a/styles/templates/property-details/property-details.css
+++ b/styles/templates/property-details/property-details.css
@@ -1,0 +1,396 @@
+.property-container {
+  max-width: var(--normal-page-width);
+  margin: 0 auto;
+  width: 100%;
+  padding: 0 var(--section-padding);
+}
+
+.accordion-item .property-container {
+  max-width: var(--normal-page-width);
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.property-row {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 0 -15px;
+}
+
+.col {
+  position: relative;
+  width: 100%;
+  min-height: 1px;
+  padding-right: var(--section-padding);
+  padding-left: var(--section-padding);
+}
+
+.col-auto {
+  flex: 0 0 auto;
+  width: auto;
+  max-width: none;
+}
+
+.col-3 {
+  flex: 0 0 25%;
+  max-width: 25%;
+}
+
+.col-4 {
+  flex: 0 0 33.333%;
+  max-width: 33.333%;
+}
+
+.col-5 {
+  flex: 0 0 41.667%;
+  max-width: 41.667%;
+}
+
+.col-6 {
+  flex: 0 0 50%;
+  max-width: 50%;
+}
+
+.col-7 {
+  flex: 0 0 58.333%;
+  max-width: 58.333%;
+}
+
+.col-9 {
+  flex: 0 0 75%;
+  max-width: 75%;
+}
+
+.col-10 {
+  flex: 0 0 83.333%;
+  max-width: 83.333%;
+}
+
+.col-12 {
+  flex: 0 0 100%;
+  max-width: 100%;
+}
+
+.d-none {
+  display: none !important;
+}
+
+.d-block {
+  display: block !important;
+}
+
+.d-flex {
+  display: flex !important;
+}
+
+.justify-content-end {
+  justify-content: flex-end !important;
+}
+
+.m-auto {
+  margin: auto !important;
+}
+
+.mr-3, .mx-3 {
+  margin-right: 1rem !important;
+}
+
+.mt-2, .my-2 {
+  margin-top: 0.5rem !important;
+}
+
+.mr-2, .mx-2 {
+  margin-right: 0.5rem !important;
+}
+
+.mt-3, .my-3 {
+  margin-top: 1rem !important;
+}
+
+.mb-3, .my-3 {
+  margin-bottom: 1rem !important;
+}
+
+.w-100 {
+  width: 100% !important;
+}
+
+.p-0 {
+  padding: 0 !important;
+}
+
+.pl-1, .px-1 {
+  padding-left: 0.25rem !important;
+}
+
+.pb-1, .py-1 {
+  padding-bottom: 0.25rem !important;
+}
+
+.pr-1, .px-1 {
+  padding-right: 0.25rem !important;
+}
+
+.pt-1, .py-1 {
+  padding-top: 0.25rem !important;
+}
+
+.pl-2, .px-2 {
+  padding-left: 0.5rem !important;
+}
+.pr-2, .px-2 {
+  padding-right: 0.5rem !important;
+}
+
+.pb-3, .py-3 {
+  padding-bottom: 1rem !important;
+}
+
+.pt-3, .py-3 {
+  padding-top: 1rem !important;
+}
+
+.pb-4, .py-4 {
+  padding-bottom: 1.5rem !important;
+}
+
+.pb-content {
+  padding-bottom: 57px;
+}
+
+.order-0 {
+  order: 0;
+}
+
+.order-1 {
+  order: 1;
+}
+
+.order-2 {
+  order: 2;
+}
+
+.order-3 {
+  order: 3;
+}
+
+.align-items-center {
+  align-items: center !important;
+}
+
+@media (min-width: 576px) {
+  .property-container {
+      max-width: 540px;
+  }
+
+  .m-sm-0 {
+    margin: 0 !important;
+  }
+}
+
+@media (min-width: 600px) {
+  .property-container {
+    max-width: 720px;
+  }
+
+  .col-md-2 {
+    flex: 0 0 16.667%;
+    max-width: 16.667%;
+  }
+
+  .col-md-3 {
+    flex: 0 0 25%;
+    max-width: 25%;
+  }
+
+  .col-md-4 {
+    flex: 0 0 33.333%;
+    max-width: 33.333%;
+  }
+
+  .col-md-5 {
+    flex: 0 0 41.667%;
+    max-width: 41.667%;
+  }
+
+  .col-md-6 {
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+
+  .col-md-8 {
+    flex: 0 0 66.667%;
+    max-width: 66.667%;
+  }
+
+  .col-md-10 {
+    flex: 0 0 83.333%;
+    max-width: 83.333%;
+  }
+
+  .offset-md-1 {
+    margin-left: 8.333%;
+  }
+
+  .mt-md-0, .my-md-0 {
+    margin-top: 0 !important;
+  }
+
+  .mb-md-0, .my-md-0 {
+    margin-bottom: 0 !important;
+  }
+
+  .pb-content {
+    padding-bottom: 80px;
+  }
+}
+
+@media (min-width: 992px) {
+  .property-container {
+    max-width: 960px;
+  }
+
+  .col-lg-1 {
+    flex: 0 0 8.333%;
+    max-width: 8.333%;
+  }
+
+  .col-lg-2 {
+    flex: 0 0 16.667%;
+    max-width: 16.667%;
+  }
+
+  .col-lg-3 {
+    flex: 0 0 25%;
+    max-width: 25%;
+  }
+
+  .col-lg-4 {
+    flex: 0 0 33.333%;
+    max-width: 33.333%;
+  }
+
+  .col-lg-5 {
+    flex: 0 0 41.667%;
+    max-width: 41.667%;
+  }
+
+  .col-lg-6 {
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+
+  .col-lg-7 {
+    flex: 0 0 58.333%;
+    max-width: 58.333%;
+  }
+
+  .col-lg-8 {
+    flex: 0 0 66.667%;
+    max-width: 66.667%;
+  }
+
+  .col-lg-12 {
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+
+  .offset-lg-0 {
+    margin-left: 0;
+  }
+
+  .offset-lg-1 {
+    margin-left: 8.333%;
+  }
+
+  .d-lg-block {
+    display: block !important;
+  }
+  
+  .d-lg-flex {
+    display: flex !important;
+  }
+
+  .d-lg-none {
+    display: none !important;
+  }
+
+  .order-lg-1 {
+    order: 1;
+  }
+
+  .order-lg-2 {
+    order: 2;
+  }
+
+  .order-lg-3 {
+    order: 3;
+  }
+
+  .order-lg-4 {
+    order: 4;
+  }
+
+  .pt-lg-0, .py-lg-0 {
+    padding-top: 0 !important;
+  }
+
+  .pl-lg-0, .px-lg-0 {
+    padding-left: 0 !important;
+  }
+
+  .pb-lg-1, .py-lg-1 {
+    padding-bottom: 0.25rem !important;
+  }
+
+  .pt-lg-1, .py-lg-1 {
+    padding-top: 0.25rem !important;
+  }
+  
+  .mb-lg-2, .my-lg-2 {
+    margin-bottom: 0.5rem !important;
+  }
+  
+  .mt-lg-3, .my-lg-3 {
+    margin-top: 1rem !important;
+  }
+}
+
+@media (min-width: 1200px) {
+  .property-container {
+    max-width: 1400px;
+  }
+
+  .col-xl-1 {
+    flex: 0 0 8.333%;
+    max-width: 8.333%;
+  }
+
+  .col-xl-2 {
+    flex: 0 0 16.667%;
+    max-width: 16.667%;
+  }
+
+  .col-xl-4 {
+    flex: 0 0 33.333%;
+    max-width: 33.333%;
+  }
+
+  .col-xl-5 {
+    flex: 0 0 41.667%;
+    max-width: 41.667%;
+  }
+
+  .col-xl-6 {
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+
+  .offset-xl-6 {
+    margin-left: 50%;
+  }
+
+  .pb-content {
+    padding-bottom: 100px;
+  }
+}


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #11 

Test URLs:
- Before: https://main--hsf-commonmoves--hlxsites.hlx.page/drafts/propertydetails-socioecon
- After: https://property-details-socioecon--hsf-commonmoves--hlxsites.hlx.page/drafts/propertydetails-socioecon

- Blocks
    - Property Details Occupancy
    - Property Details Housing Trends
    - Property Details Economic Data
- Accordion (scripts/accordion.js to create accordion item, styles/templates/accordion/accordion.css to style)
- Property Details styling
    - styles/property-details/property-details.css to style flex
    - styles/property-details/property-details-table.css for in-common table styling