### PR TITLE
Update Juicer for new api

### DIFF
--- a/blocks/juicer/juicer.js
+++ b/blocks/juicer/juicer.js
@@ -31,10 +31,7 @@ export default async function decorate(block) {
   block.innerHTML = `
     <h2>${config.title}</h2>
     <ul class="juicer-feed" 
-      data-feed-id="${config['feed-id']}"
-      data-pages="1"
-      data-per="${config.show || ''}"
-      data-columns="${config.columns || 4}"></ul>
+      data-feed-id="${config['feed-id']}"></ul>
   `;
   io.observe(block);
 }


### PR DESCRIPTION
The Juicer call no longer needs the page, number to show, or rows.

Test URLs:
- After: https://feat-juicer-update--hsf-commonmoves--hlxsites.hlx.page/
