### PR TITLE
Create shade-icon variant for the Card block

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -131,12 +131,12 @@
   background-color: var(--light-grey);
 }
 
-.cards.shade-icon .cards-list {
+.cards.block.shade-icon .cards-list {
   gap: 70px;
   max-width: 83.333%;
 }
 
-.cards.shade-icon .cards-list .cards-item {
+.cards.block.shade-icon .cards-list .cards-item {
   background-color: var(--light-grey);
   border-top: 1px solid #000;
   min-height: 274px;
@@ -144,17 +144,17 @@
   justify-content: center;
 }
 
-.cards.shade-icon .cards-list .cards-item .card-body h4 {
+.cards.block.shade-icon .cards-list .cards-item .card-body h4 {
   text-align: center;
   padding: 8px 0 20px;
 }
 
-.cards.shade-icon .cards-list .cards-item .card-body p {
+.cards.block.shade-icon .cards-list .cards-item .card-body p {
   text-align: center;
   margin-bottom: 10px;
 }
 
-.cards.shade-icon .cards-list .cards-item .card-body .icon img {
+.cards.block.shade-icon .cards-list .cards-item .card-body .icon img {
   margin: 0 auto;
   display: block;
   height: 35px;

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -131,6 +131,36 @@
   background-color: var(--light-grey);
 }
 
+.cards.shade-icon .cards-list {
+  gap: 70px;
+  max-width: 83.333%;
+}
+
+.cards.shade-icon .cards-list .cards-item {
+  background-color: var(--light-grey);
+  border-top: 1px solid #000;
+  min-height: 274px;
+  align-items: center;
+  justify-content: center;
+}
+
+.cards.shade-icon .cards-list .cards-item .card-body h4 {
+  text-align: center;
+  padding: 8px 0 20px;
+}
+
+.cards.shade-icon .cards-list .cards-item .card-body p {
+  text-align: center;
+  margin-bottom: 10px;
+}
+
+.cards.shade-icon .cards-list .cards-item .card-body .icon img {
+  margin: 0 auto;
+  display: block;
+  height: 35px;
+  width: 35px;
+}
+
 @media screen and (min-width: 600px) {
   .cards.block.icons {
     margin: 0 auto;

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -127,6 +127,11 @@
   letter-spacing: var(--letter-spacing-xs);
 }
 
+.cards.block.shade-icon .cards-list .cards-item .card-body p {
+  text-align: center;
+  margin-bottom: 10px;
+}
+
 .section.grey-background .cards.block .cards-list .cards-item .card-image p {
   background-color: var(--light-grey);
 }
@@ -147,11 +152,6 @@
 .cards.block.shade-icon .cards-list .cards-item .card-body h4 {
   text-align: center;
   padding: 8px 0 20px;
-}
-
-.cards.block.shade-icon .cards-list .cards-item .card-body p {
-  text-align: center;
-  margin-bottom: 10px;
 }
 
 .cards.block.shade-icon .cards-list .cards-item .card-body .icon img {

--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,5 +1,5 @@
 mountpoints:
-  /: https://hsoa.sharepoint.com/:f:/r/sites/Franklin/Shared%20Documents/Website
+  /: https://adobe.sharepoint.com/:f:/r/sites/HelixProjects/Shared%20Documents/sites/hsf/commonmoves
 
 folders:
   /blog/blog-detail/: /blog/blog-detail


### PR DESCRIPTION
Added CSS to allow for this variant: Cards (shade-icon)

Fix #124 

Test URLs:
- Before: https://main--hsf-commonmoves--hlxsites.hlx.page/drafts/cards
- After: https://shade-icon-card--hsf-commonmoves--hlxsites.hlx.page/drafts/cards
