### PR TITLE
Added keep-scale class to Hero

### DIFF
--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -62,6 +62,25 @@ main .section.full-width > .hero-wrapper {
   padding: 0 16px;
 }
 
+.hero.block.keep-scale {
+  display: block;
+  height: auto;
+}
+
+.hero.block.keep-scale > div{
+  padding: 0;
+}
+
+.hero.block.keep-scale .images {
+  position: relative;
+  height: auto;
+}
+
+.hero.block.keep-scale .images picture {
+  position: relative;
+  height: auto;
+}
+
 .hero.block > div .content {
   display: flex;
   height: 100%;
@@ -112,6 +131,10 @@ main .section.full-width > .hero-wrapper {
 
   .hero.block > div {
     margin-top: 100px;
+  }
+
+  .hero.block.keep-scale > div {
+    margin-top: unset;
   }
 }
 

--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -59,8 +59,7 @@ export default async function decorate(block) {
   const wrapper = document.createElement('div');
   wrapper.append(images);
   // don't add contentWrapper if it's empty
-  if (contentWrapper.innerHTML != '')
-    wrapper.append(contentWrapper);
+  if (contentWrapper.innerHTML !== '') wrapper.append(contentWrapper);
   block.replaceChildren(wrapper);
 
   if (pictures.length > 1) {

--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -57,7 +57,10 @@ export default async function decorate(block) {
   }
 
   const wrapper = document.createElement('div');
-  wrapper.append(images, contentWrapper);
+  wrapper.append(images);
+  // don't add contentWrapper if it's empty
+  if (contentWrapper.innerHTML != '')
+    wrapper.append(contentWrapper);
   block.replaceChildren(wrapper);
 
   if (pictures.length > 1) {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -248,6 +248,20 @@ main .section.full-width > div {
   margin: 0 auto;
 }
 
+main .section.full-bleed {
+  padding: 0;
+  max-width: var(--full-page-width);
+}
+
+main .section.full-bleed div {
+  max-width: var(--full-page-width);
+}
+
+main .section.full-bleed picture img {
+  width: 100%;
+  height: auto;
+}
+
 main .section.grey-background {
   background: var(--light-grey);
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -94,7 +94,7 @@
 
   /* Common dimensions */
   --full-page-width: 100vw;
-  --wide-page-width: 1600px;
+  --wide-page-width: 1500px;
   --normal-page-width: 1350px;
 
   /* nav height */


### PR DESCRIPTION
Created a `keep-scale` class on the Hero block that scales the image rather than covering.

Fix #148 

Test URLs:
- Before: https://main--hsf-commonmoves--hlxsites.hlx.page/apex-concierge-services
- After: https://148-apex--hsf-commonmoves--hlxsites.hlx.page/apex-concierge-services
